### PR TITLE
Updated default transaction description to empty string (#1)

### DIFF
--- a/src/Argon.WebGui/src/pages/Transactions/Add/Form.tsx
+++ b/src/Argon.WebGui/src/pages/Transactions/Add/Form.tsx
@@ -273,9 +273,9 @@ export default function Form({
                         rowCounter: formValues.transactionRows.length + 1,
                         credit: null,
                         debit: null,
+                        description: "",
                         // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
                         accountId: null!,
-                        description: "test 3",
                       }),
                     );
                   }}

--- a/src/Argon.WebGui/src/pages/Transactions/Edit/Form.tsx
+++ b/src/Argon.WebGui/src/pages/Transactions/Edit/Form.tsx
@@ -200,7 +200,7 @@ export default function Form({ transaction, onSubmit, isSaving }: FormProps) {
                       rowCounter: formValues.transactionRows.length + 1,
                       credit: null,
                       debit: null,
-                      description: "test 3",
+                      description: "",
                       // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
                       accountId: null!,
                     }),


### PR DESCRIPTION
The hardcoded "test 3" descriptions in 'Add' and 'Edit' transaction forms have been updated to be an empty string by default. They were committed by mistake when developing the first version of the app.