### PR TITLE
Refine transaction sort order in TransactionsGetListRequestHandler (#9)

### DIFF
--- a/src/Argon.Application/Transactions/TransactionsGetListRequestHandler.cs
+++ b/src/Argon.Application/Transactions/TransactionsGetListRequestHandler.cs
@@ -66,7 +66,15 @@ public class TransactionsGetListRequestHandler : IRequestHandler<TransactionsGet
       .Where(transaction => request.DateFrom == null || transaction.Date >= DateOnly.FromDateTime(request.DateFrom.Value.Date))
       .Where(transaction => request.DateTo == null || transaction.Date <= DateOnly.FromDateTime(request.DateTo.Value.Date))
       .OrderByDescending(transaction => transaction.Date)
+      .ThenByDescending(transaction => transaction.Created)
+      .ThenByDescending(transaction => transaction.Id)
       .ProjectTo<TransactionsGetListResponse>(_mapper.ConfigurationProvider)
       .PaginatedListAsync(request.PageNumber, request.PageSize, cancellationToken);
+    
+    // order of the records must be deterministic and avoid random sorting
+    // when two or more records have the same Date, so that when pagination occurs
+    // no record is skipped. sorting by Id is sufficient because it is a primary key
+    // and thus is unique, but adding the Created field shows the transaction in the
+    // order they were entered too, so that's a bonus
   }
 }


### PR DESCRIPTION
Updated sorting of transactions to ensure deterministic ordering and prevent random sorting when two or more records have the same Date. This was done to ensure that when pagination occurs, no record is skipped. The sorting order now considers 'Date', 'Created', and 'Id' fields. Sorting by 'Id' is sufficient as it is unique but adding the 'Created' field also allows transactions to be sorted in the order they were entered.